### PR TITLE
"Report" se arregla a "Reporte"

### DIFF
--- a/src/views/Documents/admiDocumentos.js
+++ b/src/views/Documents/admiDocumentos.js
@@ -261,7 +261,7 @@ const AdmiDocumentos=() =>{
     <br/>         
              <select onChange={(e)=>setTipo(e.target.value)}  id="tipo2" > 
                 <option>Eligir Opcion</option>
-                <option>Report</option>
+                <option>Reporte</option>
                 <option>Instructivo</option>
                 <option>Procedimiento</option>
                 <option>Manual</option>

--- a/src/views/Documents/agregarDocumento.js
+++ b/src/views/Documents/agregarDocumento.js
@@ -132,7 +132,7 @@ export const AgregarDocumento = () => {
                   <option value="Manual">Manual</option>
                   <option value="Procedimiento">Procedimiento</option>
                   <option value="Formato">Formato</option>
-                  <option value="Report">Report</option>
+                  <option value="Reporte">Reporte</option>
                 </select>
               </div>
 


### PR DESCRIPTION
Habia un bug con la palabra que se le asignaba al tipo de documento por lo cual no se podia filtrar de la mejor manera, se lleva acabo su correción.